### PR TITLE
FIX: Aes, Blowfish, Des and Twofish decrypt() functions shred the enc…

### DIFF
--- a/src/haxe/crypto/Aes.hx
+++ b/src/haxe/crypto/Aes.hx
@@ -186,7 +186,7 @@ class Aes
 
 	public function decrypt(cipherMode:Mode, data:Bytes, ?padding:Padding=Padding.PKCS7):Bytes 
 	{
-		var out:Bytes = data;
+		var out : Bytes = data.sub(0,data.length);  // prevent input data from being changed unexpectedly
 
 		switch (cipherMode) {
 			case Mode.CBC:

--- a/src/haxe/crypto/BlowFish.hx
+++ b/src/haxe/crypto/BlowFish.hx
@@ -215,7 +215,7 @@ class BlowFish
 
     public function decrypt(cipherMode:Mode, data:Bytes, ?padding:Padding=Padding.PKCS7):Bytes 
     {
-        var out:Bytes = data;
+        var out : Bytes = data.sub(0,data.length);  // prevent input data from being changed unexpectedly
 
         switch (cipherMode) {
             case Mode.CBC:

--- a/src/haxe/crypto/Des.hx
+++ b/src/haxe/crypto/Des.hx
@@ -227,7 +227,7 @@ class Des
     
     public function decrypt(cipherMode:Mode, data:Bytes, ?padding:Padding=Padding.PKCS7):Bytes 
     {
-        var out:Bytes = data;
+        var out : Bytes = data.sub(0,data.length);  // prevent input data from being changed unexpectedly
     
         switch (cipherMode) {
             case Mode.CBC:

--- a/src/haxe/crypto/TwoFish.hx
+++ b/src/haxe/crypto/TwoFish.hx
@@ -175,7 +175,7 @@ class TwoFish
 
     public function decrypt(cipherMode:Mode, data:Bytes, ?padding:Padding=Padding.PKCS7):Bytes 
     {
-        var out:Bytes = data;
+        var out : Bytes = data.sub(0,data.length);  // prevent input data from being changed unexpectedly
 
         switch (cipherMode) {
             case Mode.CBC:


### PR DESCRIPTION
…rypted input bytes, which is highly unexpected by the caller.

Reasoning: Since the functions accept Bytes and return Bytes, there is no indication that decrypt actually happens in-place. Also, encrypt() does not do this and leaves the input bits alone: the padding functions copy the data, even PaddingNone does. So this pretty much looks like a bug.