### PR TITLE
deprecation warning fixes for extern and enum

### DIFF
--- a/src/haxe/crypto/Sha224.hx
+++ b/src/haxe/crypto/Sha224.hx
@@ -174,54 +174,45 @@ class Sha224 {
 		return n;
 	}
 
-    @:extern
-    inline static function safeAdd(x, y) {
+    extern inline static function safeAdd(x, y) {
         var lsw = (x & 0xFFFF) + (y & 0xFFFF);
         var msw = (x >>> 16) + (y >>> 16) + (lsw >>> 16);
         return ((msw & 0xFFFF) << 16) | (lsw & 0xFFFF);
     }
 
     // ++
-    @:extern
-    inline function ROTR(X, n) {
+    extern inline function ROTR(X, n) {
         return ( X >>> n ) | (X << (32 - n));
     }
 
     // ++
-    @:extern
-    inline function SHR(X, n) {
+    extern inline function SHR(X, n) {
         return ( X >>> n );
     }
 
     // ++
-    @:extern
-    inline function Ch(x, y, z) {
+    extern inline function Ch(x, y, z) {
         return ((x & y) ^ ((~x) & z));
     }
 
     // ++
-    @:extern
-    inline function Maj(x, y, z) {
+    extern inline function Maj(x, y, z) {
         return ((x & y) ^ (x & z) ^ (y & z));
     }
 
-    @:extern
-    inline function Sigma0(x) {
+    extern inline function Sigma0(x) {
         return ROTR(x, 2) ^ ROTR(x, 13) ^ ROTR(x, 22);
     }
 
-    @:extern
-    inline function Sigma1(x) {
+    extern inline function Sigma1(x) {
         return ROTR(x, 6) ^ ROTR(x, 11) ^ ROTR(x, 25);
     }
 
-    @:extern
-    inline function Gamma0(x) {
+    extern inline function Gamma0(x) {
         return ROTR(x, 7) ^ ROTR(x, 18) ^ SHR(x, 3);
     }
 
-    @:extern
-    inline function Gamma1(x) {
+    extern inline function Gamma1(x) {
         return ROTR(x, 17) ^ ROTR(x, 19) ^ SHR(x, 10);
     }
 

--- a/src/haxe/crypto/Sha256.hx
+++ b/src/haxe/crypto/Sha256.hx
@@ -175,48 +175,39 @@ class Sha256 {
 		return blks;
 	}
 
-	@:extern
-	inline function S(X, n) {
+	extern inline function S(X, n) {
 		return ( X >>> n ) | (X << (32 - n));
 	}
 
-	@:extern
-	inline function R(X, n) {
+	extern inline function R(X, n) {
 		return ( X >>> n );
 	}
 
-	@:extern
-	inline function Ch(x, y, z) {
+	extern inline function Ch(x, y, z) {
 		return ((x & y) ^ ((~x) & z));
 	}
 
-	@:extern
-	inline function Maj(x, y, z) {
+	extern inline function Maj(x, y, z) {
 		return ((x & y) ^ (x & z) ^ (y & z));
 	}
 
-	@:extern
-	inline function Sigma0256(x) {
+	extern inline function Sigma0256(x) {
 		return (S(x, 2) ^ S(x, 13) ^ S(x, 22));
 	}
 
-	@:extern
-	inline function Sigma1256(x) {
+	extern inline function Sigma1256(x) {
 		return (S(x, 6) ^ S(x, 11) ^ S(x, 25));
 	}
 
-	@:extern
-	inline function Gamma0256(x) {
+	extern inline function Gamma0256(x) {
 		return (S(x, 7) ^ S(x, 18) ^ R(x, 3));
 	}
 
-	@:extern
-	inline function Gamma1256(x) {
+	extern inline function Gamma1256(x) {
 		return (S(x, 17) ^ S(x, 19) ^ R(x, 10));
 	}
 
-	@:extern
-	inline function safeAdd(x, y) {
+	extern inline function safeAdd(x, y) {
 		var lsw = (x & 0xFFFF) + (y & 0xFFFF);
 		var msw = (x >> 16) + (y >> 16) + (lsw >> 16);
 		return (msw << 16) | (lsw & 0xFFFF);

--- a/src/haxe/crypto/mode/Mode.hx
+++ b/src/haxe/crypto/mode/Mode.hx
@@ -1,7 +1,6 @@
 package haxe.crypto.mode;
 
-@:enum
-abstract Mode(String)
+enum abstract Mode(String)
 {
     var CBC = "cbc";
     var CFB = "cfb";

--- a/src/haxe/crypto/padding/Padding.hx
+++ b/src/haxe/crypto/padding/Padding.hx
@@ -1,7 +1,6 @@
 package haxe.crypto.padding;
 
-@:enum
-abstract Padding(String)
+enum abstract Padding(String)
 {
     var PKCS7 = "PKCS7";
     var NoPadding = "NoPadding";


### PR DESCRIPTION
- Warning: `@:enum abstract` is deprecated in favor of `enum abstract`
- Warning : (WDeprecated) `@:extern` is deprecated in favor of `extern`

Haxe 4.3.1 now emits warnings about it.